### PR TITLE
[16.0][IMP] stock_available_immediately_exclude_location: Deducte the quants in excluded locations for free_qty of products

### DIFF
--- a/stock_available_immediately_exclude_location/tests/test_stock_exclude_location.py
+++ b/stock_available_immediately_exclude_location/tests/test_stock_exclude_location.py
@@ -49,13 +49,16 @@ class TestStockLogisticsWarehouse(TransactionCase):
         (move_stock | move_pack)._action_assign()
         move_stock.move_line_ids.write({"qty_done": 7.0})
         move_stock._action_done()
-        q = self.product.with_context(**ctx_loc).immediately_usable_qty
-        self.assertEqual(q, 7.0)
+        product = self.product.with_context(**ctx_loc)
+        self.assertEqual(product.immediately_usable_qty, 7.0)
+        self.assertEqual(product.free_qty, 7.0)
         move_pack.move_line_ids.write({"qty_done": 4.0})
         move_pack._action_done()
-        q = self.product.with_context(**ctx_loc).immediately_usable_qty
-        self.assertEqual(q, 11.0)
+        product = self.product.with_context(**ctx_loc)
+        self.assertEqual(product.immediately_usable_qty, 11.0)
+        self.assertEqual(product.free_qty, 11.0)
         self.pack_location.exclude_from_immediately_usable_qty = True
         self.product.invalidate_recordset()  # force recompute
-        q = self.product.with_context(**ctx_loc).immediately_usable_qty
-        self.assertEqual(q, 7.0)
+        product = self.product.with_context(**ctx_loc)
+        self.assertEqual(product.immediately_usable_qty, 7.0)
+        self.assertEqual(product.free_qty, 7.0)


### PR DESCRIPTION
### Context:
- For now, Odoo calculates the availability of products to show on SO without deducting the qty in excluded locations:
   - Widget to show available quanties of product: [here](https://github.com/odoo/odoo/blob/721ab983618107a7d3e8cb60fee4bcce8e84faab/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml#L24)
   - `free_qty_today` comes from `free_qty` field of product (It is computed from [here](https://github.com/odoo/odoo/blob/721ab983618107a7d3e8cb60fee4bcce8e84faab/addons/stock/models/product.py#L199))
   - But it didn't exclude the locations that enable `exclude_from_immediately_usable_qty` : [here](https://github.com/odoo/odoo/blob/721ab983618107a7d3e8cb60fee4bcce8e84faab/addons/stock/models/product.py#L137)
### Changes:
- Add more context in `_compute_quantities_dict` to avoid making recursive in method
- Re-compute `free_qty` by deducting the qty in excluded locations
- Refactor code in a clean way

### Result: (`Forecasted qty` and `Available qty`)
![image](https://github.com/QuocDuong1306/stock-logistics-availability/assets/127363167/0cd02b0e-8eb2-40fb-98a9-de54bf77272e)
![image](https://github.com/QuocDuong1306/stock-logistics-availability/assets/127363167/9a3b3079-3e42-44b7-810b-2270b68c6271)
